### PR TITLE
Improve DateTime accuracy

### DIFF
--- a/moor/lib/src/runtime/query_builder/expressions/datetimes.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/datetimes.dart
@@ -86,7 +86,7 @@ extension DateTimeExpressions on Expression<DateTime, DateTimeType> {
   /// assumed to be in utc.
   // for moor, date times are just unix timestamps, so we don't need to rewrite
   // anything when converting
-  Expression<int, IntType> get secondsSinceEpoch => dartCast();
+  Expression<int, IntType> get millisecondsSinceEpoch => dartCast();
 }
 
 /// Expression that extracts components out of a date time by using the builtin

--- a/moor/lib/src/runtime/types/sql_types.dart
+++ b/moor/lib/src/runtime/types/sql_types.dart
@@ -115,23 +115,23 @@ class DateTimeType extends SqlType<DateTime>
   DateTime mapFromDatabaseResponse(response) {
     if (response == null) return null;
 
-    final unixSeconds = response as int;
+    final unixMilliseconds = response as int;
 
-    return DateTime.fromMillisecondsSinceEpoch(unixSeconds * 1000);
+    return DateTime.fromMillisecondsSinceEpoch(unixMilliseconds);
   }
 
   @override
   String mapToSqlConstant(DateTime content) {
     if (content == null) return 'NULL';
 
-    return (content.millisecondsSinceEpoch ~/ 1000).toString();
+    return content.millisecondsSinceEpoch.toString();
   }
 
   @override
   mapToSqlVariable(DateTime content) {
     if (content == null) return null;
 
-    return content.millisecondsSinceEpoch ~/ 1000;
+    return content.millisecondsSinceEpoch;
   }
 }
 


### PR DESCRIPTION
Convert DateTime objects into millisecond instead of second to the
sqlite.